### PR TITLE
Fetch thumbnail from external URL.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "scrivito-youtube-video-widget",
-  "version": "0.1.4",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrivito-youtube-video-widget",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A Scrivito widget that plays videos from YouTube.",
   "main": "index.js",
   "author": "Infopark AG",

--- a/src/YoutubeVideoWidgetEditingConfig.js
+++ b/src/YoutubeVideoWidgetEditingConfig.js
@@ -1,9 +1,9 @@
 import * as Scrivito from "scrivito";
-import thumbnail from "./YoutubeVideoWidgetThumbnail.svg";
 
 Scrivito.provideEditingConfig("YoutubeVideoWidget", {
   title: "YouTube Video",
-  thumbnail,
+  thumbnail:
+    "https://long-lasting-assets.scrivitojs.com/npmjs.com/scrivito-youtube-video-widget/YoutubeVideoWidgetThumbnail.svg",
   attributes: {
     youtubeVideoId: {
       title: "YouTube video ID",


### PR DESCRIPTION
This slims down the package by 2kb (of 5kb), since it no longer needs to inline the svg as base64.